### PR TITLE
Migrating to CocoaLumberjack 2.x

### DIFF
--- a/Classes/Core/K9LogMessage.h
+++ b/Classes/Core/K9LogMessage.h
@@ -17,10 +17,10 @@ typedef NS_ENUM(NSInteger, K9LogMessageLevel) {
 
 - (NSDate *)k9_timestamp;
 
-- (const char *)k9_filePath;
+- (NSString *)k9_filePath;
 
 - (NSInteger)k9_lineNumber;
 
-- (const char *)k9_methodName;
+- (NSString *)k9_methodName;
 
 @end

--- a/Classes/Core/K9LogMessage.h
+++ b/Classes/Core/K9LogMessage.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(NSInteger, K9LogMessageLevel) {
 
 - (NSString *)k9_filePath;
 
-- (NSInteger)k9_lineNumber;
+- (NSUInteger)k9_lineNumber;
 
 - (NSString *)k9_methodName;
 

--- a/Classes/Core/K9LogPatternComponent.m
+++ b/Classes/Core/K9LogPatternComponent.m
@@ -102,7 +102,7 @@
 
 - (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
 {
-    return [NSString stringWithFormat:@"%ld", (long)[logMessage k9_lineNumber]];
+    return [NSString stringWithFormat:@"%lu", (unsigned long)[logMessage k9_lineNumber]];
 }
 
 @end

--- a/Classes/Core/K9LogPatternComponent.m
+++ b/Classes/Core/K9LogPatternComponent.m
@@ -45,7 +45,7 @@ static NSString *createStringWithUTF8BytesNoCopy(const char *bytes)
 
 - (instancetype)init
 {
-    return [self initWithParameters:@[]];
+    return [super init];
 }
 
 - (instancetype)initWithParameters:(NSArray *)parameters

--- a/Classes/Core/K9LogPatternComponent.m
+++ b/Classes/Core/K9LogPatternComponent.m
@@ -1,17 +1,5 @@
 #import "K9LogPatternComponent.h"
 
-static NSString *createStringWithUTF8BytesNoCopy(const char *bytes)
-{
-    if (!bytes) {
-        return nil;
-    }
-
-    return [[NSString alloc] initWithBytesNoCopy:(char *)bytes
-                                          length:strlen(bytes)
-                                        encoding:NSUTF8StringEncoding
-                                    freeWhenDone:NO];
-}
-
 @implementation K9LogPatternLiteralTextComponent
 
 - (instancetype)init
@@ -103,7 +91,7 @@ static NSString *createStringWithUTF8BytesNoCopy(const char *bytes)
 
 - (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
 {
-    return createStringWithUTF8BytesNoCopy([logMessage k9_filePath]);
+    return [logMessage k9_filePath];
 }
 
 @end
@@ -125,7 +113,7 @@ static NSString *createStringWithUTF8BytesNoCopy(const char *bytes)
 
 - (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
 {
-    return createStringWithUTF8BytesNoCopy([logMessage k9_methodName]);
+    return [logMessage k9_methodName];
 }
 
 @end

--- a/Classes/Core/K9LogPatternFileNameComponent.m
+++ b/Classes/Core/K9LogPatternFileNameComponent.m
@@ -4,7 +4,7 @@
 
 - (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
 {
-    const char *filePath = [logMessage k9_filePath];
+    const char *filePath = [[logMessage k9_filePath] UTF8String];
 
     if (!filePath) {
         return nil;

--- a/Classes/Lumberjack/K9LogLumberjackPatternFormatter.h
+++ b/Classes/Lumberjack/K9LogLumberjackPatternFormatter.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "DDLog.h"
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 @interface K9LogLumberjackPatternFormatter : NSObject <DDLogFormatter>
 

--- a/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
+++ b/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
@@ -41,9 +41,9 @@
     return self.timestamp;
 }
 
-- (const char *)k9_filePath
+- (NSString *)k9_filePath
 {
-    return [self.file UTF8String];
+    return self.file;
 }
 
 - (NSInteger)k9_lineNumber
@@ -51,9 +51,9 @@
     return self.line;
 }
 
-- (const char *)k9_methodName
+- (NSString *)k9_methodName
 {
-    return [self.function UTF8String];
+    return self.function;
 }
 
 @end

--- a/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
+++ b/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
@@ -12,47 +12,48 @@
 
 - (NSString *)k9_messageText
 {
-    return self->logMsg;
+    return self.message;
 }
 
 - (K9LogMessageLevel)k9_logLevel
 {
-    const NSInteger level = self->logFlag;
+    // CocoaLumberjack: DDLogFlag is constant value, but DDLogLevel is bitmask.
+    const DDLogFlag flag = self.flag;
 
-    switch (level) {
-        case LOG_FLAG_VERBOSE:
+    switch (flag) {
+        case DDLogFlagVerbose:
             return K9LogMessageLevelVerbose;
-        case LOG_FLAG_DEBUG:
+        case DDLogFlagDebug:
             return K9LogMessageLevelDebug;
-        case LOG_FLAG_INFO:
+        case DDLogFlagInfo:
             return K9LogMessageLevelInfo;
-        case LOG_FLAG_WARN:
+        case DDLogFlagWarning:
             return K9LogMessageLevelWarn;
-        case LOG_FLAG_ERROR:
+        case DDLogFlagError:
             return K9LogMessageLevelError;
         default:
-            return K9LogMessageLevelCustomBase + level;
+            return K9LogMessageLevelCustomBase + flag;
     }
 }
 
 - (NSDate *)k9_timestamp
 {
-    return self->timestamp;
+    return self.timestamp;
 }
 
 - (const char *)k9_filePath
 {
-    return self->file;
+    return [self.file UTF8String];
 }
 
 - (NSInteger)k9_lineNumber
 {
-    return self->lineNumber;
+    return self.line;
 }
 
 - (const char *)k9_methodName
 {
-    return self->function;
+    return [self.function UTF8String];
 }
 
 @end

--- a/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
+++ b/Classes/Lumberjack/K9LogLumberjackPatternFormatter.m
@@ -46,7 +46,7 @@
     return self.file;
 }
 
-- (NSInteger)k9_lineNumber
+- (NSUInteger)k9_lineNumber
 {
     return self.line;
 }

--- a/K9LogPatternFormatter.podspec
+++ b/K9LogPatternFormatter.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'Lumberjack' do |lumberjack|
     lumberjack.source_files = 'Classes/Lumberjack/**/*.{h,m}'
     lumberjack.dependency 'K9LogPatternFormatter/Core'
-    lumberjack.dependency 'CocoaLumberjack'
+    lumberjack.dependency 'CocoaLumberjack/Default'
   end
 
 end

--- a/K9LogPatternFormatter.xcodeproj/project.pbxproj
+++ b/K9LogPatternFormatter.xcodeproj/project.pbxproj
@@ -90,7 +90,9 @@
 
 /* Begin PBXFileReference section */
 		1C036EA4341A42D187BEBACE /* libPods-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		99C444FC13A94FEA90254C72 /* Pods-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSX.xcconfig"; path = "Pods/Pods-OSX.xcconfig"; sourceTree = "<group>"; };
+		3839238F17DDDEA6A0D7702D /* Pods-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS/Pods-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		42D1560FC75D5B48837C3E94 /* Pods-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OSX/Pods-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		7B2ECBC8826CD2796E9279A9 /* Pods-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS/Pods-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		A50F7AA118C5B4C8003B795E /* K9LogLevelPatternComponentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogLevelPatternComponentTests.m; sourceTree = "<group>"; };
 		A50F7AA518C5CBE9003B795E /* K9LogPatternMinWidthConstraintTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogPatternMinWidthConstraintTests.m; sourceTree = "<group>"; };
 		A50F7AA818C5D498003B795E /* K9LogPatternMaxWidthConstraintTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogPatternMaxWidthConstraintTests.m; sourceTree = "<group>"; };
@@ -130,8 +132,8 @@
 		A5EF2DE718B923910072971D /* iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5EF2DEA18B923910072971D /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		A5EF2E0018B996770072971D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		A75208F89ED241A9AC32F0B5 /* Pods-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS.xcconfig"; path = "Pods/Pods-iOS.xcconfig"; sourceTree = "<group>"; };
 		BCACFE782CAE4A30B1EC91D4 /* libPods-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C2092C26A6A3587613A55B74 /* Pods-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-OSX/Pods-OSX.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +159,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E547957216626A7C615336F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				42D1560FC75D5B48837C3E94 /* Pods-OSX.debug.xcconfig */,
+				C2092C26A6A3587613A55B74 /* Pods-OSX.release.xcconfig */,
+				3839238F17DDDEA6A0D7702D /* Pods-iOS.debug.xcconfig */,
+				7B2ECBC8826CD2796E9279A9 /* Pods-iOS.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		A50F7AA418C5CBBB003B795E /* Pattern Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -277,8 +290,7 @@
 				A580A20418C2C2EA00AD8F75 /* Tests */,
 				A5EF2DE918B923910072971D /* Frameworks */,
 				A5EF2DE818B923910072971D /* Products */,
-				99C444FC13A94FEA90254C72 /* Pods-OSX.xcconfig */,
-				A75208F89ED241A9AC32F0B5 /* Pods-iOS.xcconfig */,
+				0E547957216626A7C615336F /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -430,7 +442,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-OSX-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OSX/Pods-OSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F9BD64B0A8364DCCBB7B4C4E /* Copy Pods Resources */ = {
@@ -445,7 +457,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-iOS-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOS/Pods-iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -525,7 +537,7 @@
 /* Begin XCBuildConfiguration section */
 		A580A1F218C2B89900AD8F75 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 99C444FC13A94FEA90254C72 /* Pods-OSX.xcconfig */;
+			baseConfigurationReference = 42D1560FC75D5B48837C3E94 /* Pods-OSX.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -572,7 +584,7 @@
 		};
 		A580A1F318C2B89900AD8F75 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 99C444FC13A94FEA90254C72 /* Pods-OSX.xcconfig */;
+			baseConfigurationReference = C2092C26A6A3587613A55B74 /* Pods-OSX.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -639,7 +651,7 @@
 		};
 		A5EF2DFA18B923910072971D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A75208F89ED241A9AC32F0B5 /* Pods-iOS.xcconfig */;
+			baseConfigurationReference = 3839238F17DDDEA6A0D7702D /* Pods-iOS.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
@@ -688,7 +700,7 @@
 		};
 		A5EF2DFB18B923910072971D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A75208F89ED241A9AC32F0B5 /* Pods-iOS.xcconfig */;
+			baseConfigurationReference = 7B2ECBC8826CD2796E9279A9 /* Pods-iOS.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";

--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,9 @@
 target 'iOS' do
   platform :ios, '7.0'
-  pod 'CocoaLumberjack'
+  pod 'CocoaLumberjack/Default'
 end
 
 target 'OSX' do
   platform :osx, '10.8'
-  pod 'CocoaLumberjack'
+  pod 'CocoaLumberjack/Default'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,12 @@
 PODS:
-  - CocoaLumberjack (1.8.1):
-    - CocoaLumberjack/Extensions
-  - CocoaLumberjack/Core (1.8.1)
-  - CocoaLumberjack/Extensions (1.8.1):
+  - CocoaLumberjack/Core (2.0.1)
+  - CocoaLumberjack/Default (2.0.1):
     - CocoaLumberjack/Core
 
 DEPENDENCIES:
-  - CocoaLumberjack
+  - CocoaLumberjack/Default
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 020378ec400d658923bf5887178394f65f052c90
+  CocoaLumberjack: 019d1361244274a6138c788c6cb80baabc13fb8f
 
-COCOAPODS: 0.29.0
+COCOAPODS: 0.38.2

--- a/Tests/Classes/K9LumberjackPatternLogFormatterTests.m
+++ b/Tests/Classes/K9LumberjackPatternLogFormatterTests.m
@@ -15,7 +15,7 @@
 {
     return [self formatLogMessageWithPattern:pattern
                                      message:@""
-                                        flag:LOG_FLAG_VERBOSE
+                                        flag:DDLogFlagVerbose
                                         file:@"test.m"
                                         line:1
                                   methodName:methodName
@@ -28,7 +28,7 @@
 {
     return [self formatLogMessageWithPattern:pattern
                                      message:@""
-                                        flag:LOG_FLAG_VERBOSE
+                                        flag:DDLogFlagVerbose
                                         file:file
                                         line:line
                                   methodName:@""
@@ -40,7 +40,7 @@
 {
     return [self formatLogMessageWithPattern:pattern
                                      message:message
-                                        flag:LOG_FLAG_VERBOSE
+                                        flag:DDLogFlagVerbose
                                         file:@"test.m"
                                         line:1
                                   methodName:@""
@@ -65,7 +65,7 @@
 {
     return [self formatLogMessageWithPattern:pattern
                                      message:@""
-                                        flag:LOG_FLAG_VERBOSE
+                                        flag:DDLogFlagVerbose
                                         file:@"test.m"
                                         line:1
                                   methodName:@""
@@ -84,19 +84,16 @@
 
     XCTAssertNotNil(formatter, @"formatter for %@", pattern);
 
-    DDLogMessage *logMessage = [[DDLogMessage alloc] initWithLogMsg:message
-                                                              level:LOG_LEVEL_VERBOSE
-                                                               flag:flag
-                                                            context:0
-                                                               file:[file UTF8String]
-                                                           function:[methodName UTF8String]
-                                                               line:line
-                                                                tag:nil
-                                                            options:0];
-
-    if (timestamp) {
-        logMessage->timestamp = timestamp;
-    }
+    DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message
+                                                               level:DDLogLevelVerbose
+                                                                flag:flag
+                                                             context:0
+                                                                file:file
+                                                            function:methodName
+                                                                line:line
+                                                                 tag:nil
+                                                             options:0
+                                                           timestamp:timestamp];
 
     return [formatter formatLogMessage:logMessage];
 }
@@ -199,16 +196,16 @@
 
 - (void)testFormatLogMessage_logLevel
 {
-    NSDictionary *stringByLevel = @{
-                                    @(LOG_FLAG_VERBOSE): @"VERBOSE",
-                                    @(LOG_FLAG_DEBUG):   @"DEBUG",
-                                    @(LOG_FLAG_INFO):    @"INFO",
-                                    @(LOG_FLAG_WARN):    @"WARN",
-                                    @(LOG_FLAG_ERROR):   @"ERROR",
+    NSDictionary *stringByFlag = @{
+                                    @(DDLogFlagVerbose): @"VERBOSE",
+                                    @(DDLogFlagDebug):   @"DEBUG",
+                                    @(DDLogFlagInfo):    @"INFO",
+                                    @(DDLogFlagWarning): @"WARN",
+                                    @(DDLogFlagError):   @"ERROR",
                                     @(1000):             @"CUSTOM",
                                     };
 
-    [stringByLevel enumerateKeysAndObjectsUsingBlock:^(NSNumber *flag, NSString *label, BOOL *stop) {
+    [stringByFlag enumerateKeysAndObjectsUsingBlock:^(NSNumber *flag, NSString *label, BOOL *stop) {
         NSString *text = [self formatLogMessageWithPattern:@"[%p] %m"
                                                    message:@"MESSAGE"
                                                       flag:[flag intValue]];
@@ -328,13 +325,13 @@
         {
             NSString *text = [self formatLogMessageWithPattern:@"%-5p %m"
                                                        message:@"Message"
-                                                          flag:LOG_FLAG_DEBUG];
+                                                          flag:DDLogFlagDebug];
             XCTAssertEqualObjects(text, @"DEBUG Message");
         }
         {
             NSString *text = [self formatLogMessageWithPattern:@"%-5p %m"
                                                        message:@"Message"
-                                                          flag:LOG_FLAG_WARN];
+                                                          flag:DDLogFlagWarning];
             XCTAssertEqualObjects(text, @"WARN  Message");
         }
     }

--- a/Tests/Classes/LogMessage.h
+++ b/Tests/Classes/LogMessage.h
@@ -7,7 +7,7 @@
 @property (nonatomic) K9LogMessageLevel  level;
 @property (nonatomic) NSDate            *timestamp;
 @property (nonatomic) NSString          *filePath;
-@property (nonatomic) NSInteger          lineNumber;
+@property (nonatomic) NSUInteger         lineNumber;
 @property (nonatomic) NSString          *methodName;
 
 @end

--- a/Tests/Classes/LogMessage.m
+++ b/Tests/Classes/LogMessage.m
@@ -28,9 +28,9 @@
     return self.timestamp;
 }
 
-- (const char *)k9_filePath
+- (NSString *)k9_filePath
 {
-    return [self.filePath UTF8String];
+    return self.filePath;
 }
 
 - (NSInteger)k9_lineNumber
@@ -38,9 +38,9 @@
     return self.lineNumber;
 }
 
-- (const char *)k9_methodName
+- (NSString *)k9_methodName
 {
-    return [self.methodName UTF8String];
+    return self.methodName;
 }
 
 @end

--- a/Tests/Classes/LogMessage.m
+++ b/Tests/Classes/LogMessage.m
@@ -33,7 +33,7 @@
     return self.filePath;
 }
 
-- (NSInteger)k9_lineNumber
+- (NSUInteger)k9_lineNumber
 {
     return self.lineNumber;
 }


### PR DESCRIPTION
### Todo
- [x] Depends only `CocoaLumnerjack/Default`
- [x] Migrating to 2.x (See [CocoaLumberjack README](https://github.com/CocoaLumberjack/CocoaLumberjack#migrating-to-2x)
- [x] API changes to follow ARC convention
