### PR TITLE
Add single percent sign pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.0
+
+* New patterns
+  - Single percent sign pattern `%%`
+
 ## 1.0.0
 
 * Migrating to CocoaLumberjack 2.x

--- a/Classes/Core/K9LogPatternComponent.h
+++ b/Classes/Core/K9LogPatternComponent.h
@@ -41,6 +41,12 @@
 
 @end
 
+#pragma mark K9LogPatternLiteralPercentSignComponent
+
+@interface K9LogPatternLiteralPercentSignComponent : NSObject <K9LogPatternComponent>
+
+@end
+
 #pragma mark K9LogPatternMessageComponent
 
 @interface K9LogPatternMessageComponent : NSObject <K9LogPatternComponent>

--- a/Classes/Core/K9LogPatternComponent.h
+++ b/Classes/Core/K9LogPatternComponent.h
@@ -43,7 +43,7 @@
 
 #pragma mark K9LogPatternLiteralPercentSignComponent
 
-@interface K9LogPatternLiteralPercentSignComponent : NSObject <K9LogPatternComponent>
+@interface K9LogPatternPercentSignComponent : NSObject <K9LogPatternComponent>
 
 @end
 

--- a/Classes/Core/K9LogPatternComponent.m
+++ b/Classes/Core/K9LogPatternComponent.m
@@ -29,7 +29,7 @@
 
 @end
 
-@implementation K9LogPatternLiteralPercentSignComponent
+@implementation K9LogPatternPercentSignComponent
 
 - (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
 {

--- a/Classes/Core/K9LogPatternComponent.m
+++ b/Classes/Core/K9LogPatternComponent.m
@@ -29,6 +29,15 @@
 
 @end
 
+@implementation K9LogPatternLiteralPercentSignComponent
+
+- (NSString *)stringFromLogMessage:(id<K9LogMessage>)logMessage
+{
+    return @"%";
+}
+
+@end
+
 @implementation K9LogPatternParameterizedComponent
 
 - (instancetype)init

--- a/Classes/Core/K9LogPatternParser.m
+++ b/Classes/Core/K9LogPatternParser.m
@@ -65,7 +65,7 @@ NSString *const K9LogPatternParserErrorDomain = @"jp.ko9.LogPatternParser.ErrorD
             } else if ([scanner scanString:@"M" intoString:NULL]) {
                 componentClass = [K9LogPatternMethodNameComponent class];
             } else if ([scanner scanString:@"%" intoString:NULL]) {
-                componentClass = [K9LogPatternLiteralPercentSignComponent class];
+                componentClass = [K9LogPatternPercentSignComponent class];
             } else {
                 if (errorPtr != NULL) {
                     *errorPtr = [NSError errorWithDomain:K9LogPatternParserErrorDomain

--- a/Classes/Core/K9LogPatternParser.m
+++ b/Classes/Core/K9LogPatternParser.m
@@ -64,6 +64,8 @@ NSString *const K9LogPatternParserErrorDomain = @"jp.ko9.LogPatternParser.ErrorD
                 componentClass = [K9LogPatternLineNumberComponent class];
             } else if ([scanner scanString:@"M" intoString:NULL]) {
                 componentClass = [K9LogPatternMethodNameComponent class];
+            } else if ([scanner scanString:@"%" intoString:NULL]) {
+                componentClass = [K9LogPatternLiteralPercentSignComponent class];
             } else {
                 if (errorPtr != NULL) {
                     *errorPtr = [NSError errorWithDomain:K9LogPatternParserErrorDomain

--- a/K9LogPatternFormatter.xcodeproj/project.pbxproj
+++ b/K9LogPatternFormatter.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		A52CE93118C9E169000D2670 /* K9LogPatternFileNameComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = A52CE93018C9E169000D2670 /* K9LogPatternFileNameComponent.m */; };
 		A52CE93218C9E169000D2670 /* K9LogPatternFileNameComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = A52CE93018C9E169000D2670 /* K9LogPatternFileNameComponent.m */; };
 		A52E54DB1BC3FB0F0017D16A /* CocoaLumberjackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A52E54DA1BC3FB0F0017D16A /* CocoaLumberjackTests.m */; settings = {ASSET_TAGS = (); }; };
+		A52E55111BCDD8A20017D16A /* K9LogPatternPercentSignComponentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A52E55101BCDD8A20017D16A /* K9LogPatternPercentSignComponentTests.m */; settings = {ASSET_TAGS = (); }; };
 		A550A24B18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A550A24A18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m */; };
 		A550A24C18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A550A24A18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m */; };
 		A580A1E718C2B89900AD8F75 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5EF2DEA18B923910072971D /* XCTest.framework */; };
@@ -111,6 +112,7 @@
 		A52CE92F18C9E169000D2670 /* K9LogPatternFileNameComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = K9LogPatternFileNameComponent.h; sourceTree = "<group>"; };
 		A52CE93018C9E169000D2670 /* K9LogPatternFileNameComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogPatternFileNameComponent.m; sourceTree = "<group>"; };
 		A52E54DA1BC3FB0F0017D16A /* CocoaLumberjackTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CocoaLumberjackTests.m; sourceTree = "<group>"; };
+		A52E55101BCDD8A20017D16A /* K9LogPatternPercentSignComponentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogPatternPercentSignComponentTests.m; sourceTree = "<group>"; };
 		A550A24A18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = K9LogPatternMethodNameComponentTests.m; sourceTree = "<group>"; };
 		A580A1E618C2B89900AD8F75 /* OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSX.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A580A20718C2C2EA00AD8F75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				A52CE92218C8B0B7000D2670 /* K9LogPatternFilePathComponentTests.m */,
 				A52CE92518C8B15E000D2670 /* K9LogPatternLineNumberComponentTests.m */,
 				A550A24A18CE0872007E236B /* K9LogPatternMethodNameComponentTests.m */,
+				A52E55101BCDD8A20017D16A /* K9LogPatternPercentSignComponentTests.m */,
 			);
 			name = "Pattern Component";
 			sourceTree = "<group>";
@@ -501,6 +504,7 @@
 				A50F7AA218C5B4C8003B795E /* K9LogLevelPatternComponentTests.m in Sources */,
 				A50F7AB218C5F1FF003B795E /* K9LogPatternDateComponent.m in Sources */,
 				A580A23418C2D5F500AD8F75 /* K9LogLumberjackPatternFormatter.m in Sources */,
+				A52E55111BCDD8A20017D16A /* K9LogPatternPercentSignComponentTests.m in Sources */,
 				A580A23218C2D5F500AD8F75 /* K9LogPatternParser.m in Sources */,
 				A580A23E18C4A1EC00AD8F75 /* K9LogLiteralTextComponentTests.m in Sources */,
 				A580A24518C4B9BE00AD8F75 /* K9LogMessagePatternComponentTests.m in Sources */,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Supported patterns:
 * `%l` file path
 * `%L` line number
 * `%M` function or method name
+* `%%` single percent sign (`'%'`)
 
 Min/max width modifier is also supported:
 

--- a/Tests/Classes/CocoaLumberjackTests.m
+++ b/Tests/Classes/CocoaLumberjackTests.m
@@ -2,22 +2,68 @@
 #import <CocoaLumberjack/CocoaLumberjack.h>
 #import "K9LogLumberjackPatternFormatter.h"
 
-static const DDLogLevel ddLogLevel = DDLogLevelWarning;
+static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
+
+#pragma mark - MemoryLogger
+
+@interface MemoryLogger : NSObject<DDLogger>
+
+@property (nonatomic, strong)   id <DDLogFormatter> logFormatter;
+@property (nonatomic, strong) NSString           *lastMessage;
+
+@end
+
+@implementation MemoryLogger
+
+- (void)logMessage:(DDLogMessage *)logMessage
+{
+    self.lastMessage = [_logFormatter formatLogMessage:logMessage];
+}
+
+@end
+
+#pragma mark - CocoaLumberjackTests
 
 @interface CocoaLumberjackTests : XCTestCase
+
+@property (nonatomic) MemoryLogger *memoryLogger;
 
 @end
 
 @implementation CocoaLumberjackTests
 
-- (void)testLogger {
-    id<DDLogger> consoleLogger = [DDTTYLogger sharedInstance];
+- (void)setUp
+{
+    _memoryLogger = [[MemoryLogger alloc] init];
 
-    consoleLogger.logFormatter = [[K9LogLumberjackPatternFormatter alloc] initWithPattern:@"%.1p: %m"];
+    [DDLog removeAllLoggers];
+    [DDLog addLogger:_memoryLogger];
 
-    [DDLog addLogger:consoleLogger];
+    [super setUp];
+}
 
-    DDLogVerbose(@"OK");
+- (void)assertLogWithPattern:(NSString *)pattern
+                     message:(NSString *)message
+                    shouldBe:(NSString *)expectation
+{
+    _memoryLogger.logFormatter = [[K9LogLumberjackPatternFormatter alloc] initWithPattern:pattern];
+
+    DDLogVerbose(message);
+    [DDLog flushLog];
+
+    XCTAssertEqualObjects(_memoryLogger.lastMessage, expectation);
+}
+
+- (void)testLogLevelMinLength {
+    [self assertLogWithPattern:@"%.1p: %m"
+                       message:@"OK"
+                      shouldBe:@"V: OK"];
+}
+
+- (void)testSinglePercentSign {
+    [self assertLogWithPattern:@"%%%m"
+                       message:@"OK"
+                      shouldBe:@"%OK"];
 }
 
 @end

--- a/Tests/Classes/K9LogPatternParserTests.m
+++ b/Tests/Classes/K9LogPatternParserTests.m
@@ -75,7 +75,7 @@
     K9LogPatternParseResult *components = [self parseComponentsFromPattern:@"%%"];
 
     XCTAssertEqual(components.count, (NSUInteger)1, @"1 component");
-    XCTAssertTrue([components[0] isKindOfClass:[K9LogPatternLiteralPercentSignComponent class]],
+    XCTAssertTrue([components[0] isKindOfClass:[K9LogPatternPercentSignComponent class]],
                   @"1st component");
 }
 

--- a/Tests/Classes/K9LogPatternParserTests.m
+++ b/Tests/Classes/K9LogPatternParserTests.m
@@ -70,6 +70,15 @@
     }
 }
 
+- (void)testLiteralPercentSign
+{
+    K9LogPatternParseResult *components = [self parseComponentsFromPattern:@"%%"];
+
+    XCTAssertEqual(components.count, (NSUInteger)1, @"1 component");
+    XCTAssertTrue([components[0] isKindOfClass:[K9LogPatternLiteralPercentSignComponent class]],
+                  @"1st component");
+}
+
 - (void)testPatternMapping
 {
     NSDictionary *klassByPattern = @{

--- a/Tests/Classes/K9LogPatternPercentSignComponentTests.m
+++ b/Tests/Classes/K9LogPatternPercentSignComponentTests.m
@@ -1,0 +1,19 @@
+#import <XCTest/XCTest.h>
+#import "K9LogPatternComponent.h"
+#import "LogMessage.h"
+
+@interface K9LogPatternPercentSignComponentTests : XCTestCase
+
+@end
+
+@implementation K9LogPatternPercentSignComponentTests
+
+- (void)testInit
+{
+    LogMessage *message = [[LogMessage alloc] init];
+    K9LogPatternPercentSignComponent *component = [[K9LogPatternPercentSignComponent alloc] init];
+
+    XCTAssertEqualObjects([component stringFromLogMessage:message], @"%");
+}
+
+@end


### PR DESCRIPTION
The sequence `%%` in format outputs a single percent sign.

The pattern:

```
"%%"
```

outputs:

```
%
```
