### PR TITLE
Support long pattern name

### DIFF
--- a/Classes/Core/K9LogPatternParser.m
+++ b/Classes/Core/K9LogPatternParser.m
@@ -50,7 +50,24 @@ NSString *const K9LogPatternParserErrorDomain = @"jp.ko9.LogPatternParser.ErrorD
 
             Class componentClass = nil;
 
-            if ([scanner scanString:@"m" intoString:NULL]) {
+            // Long names
+            if ([scanner scanString:@"message" intoString:NULL]) {
+                componentClass = [K9LogPatternMessageComponent class];
+            } else if ([scanner scanString:@"level" intoString:NULL]) {
+                componentClass = [K9LogPatternLevelComponent class];
+            } else if ([scanner scanString:@"date" intoString:NULL]) {
+                componentClass = [K9LogPatternDateComponent class];
+            } else if ([scanner scanString:@"file" intoString:NULL]) {
+                componentClass = [K9LogPatternFileNameComponent class];
+            } else if ([scanner scanString:@"location" intoString:NULL]) {
+                componentClass = [K9LogPatternFilePathComponent class];
+            } else if ([scanner scanString:@"line" intoString:NULL]) {
+                componentClass = [K9LogPatternLineNumberComponent class];
+            } else if ([scanner scanString:@"method" intoString:NULL]) {
+                componentClass = [K9LogPatternMethodNameComponent class];
+            }
+            // Short names
+            else if ([scanner scanString:@"m" intoString:NULL]) {
                 componentClass = [K9LogPatternMessageComponent class];
             } else if ([scanner scanString:@"p" intoString:NULL]) {
                 componentClass = [K9LogPatternLevelComponent class];

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ consoleLogger.logFormatter = [[K9LogLumberjackPatternFormatter alloc] initWithPa
 
 Supported patterns:
 
-* `%d{pattern}` timestamp formatted by using `NSDateFormatter`
+* `%d{pattern}`, `%date{pattern}` timestamp formatted by using `NSDateFormatter`
     * `%d{HH':'mm':'ss}` prints `14:34:02`
     * Threre are some predefined formats:
         1. `%d{ISO8601}` prints `2014-03-12 14:34:02,781`
@@ -32,12 +32,12 @@ Supported patterns:
         4. `%d{DATE}` prints `12 Mar 2014 14:34:02,781`
         5. `%d{COMPACT}` prints `20140312143402781`
     * If no format is given, `ISO8601` is used.
-* `%m` message
-* `%p` log level
-* `%F` file name without extension
-* `%l` file path
-* `%L` line number
-* `%M` function or method name
+* `%m`, `%message` message
+* `%p`, `%level` log level
+* `%F`, `%file` file name without extension
+* `%l`, `%location` file path
+* `%L`, `%line` line number
+* `%M`, `%method` function or method name
 * `%%` single percent sign (`'%'`)
 
 Min/max width modifier is also supported:
@@ -80,4 +80,3 @@ or, you can grab core classes to writting your own formatter:
 ## License
 
 MIT license
-

--- a/Tests/Classes/K9LogPatternParserTests.m
+++ b/Tests/Classes/K9LogPatternParserTests.m
@@ -92,6 +92,14 @@
                                      @"%l": [K9LogPatternFilePathComponent class],
                                      @"%L": [K9LogPatternLineNumberComponent class],
                                      @"%M": [K9LogPatternMethodNameComponent class],
+
+                                     // Long form
+                                     @"%message": [K9LogPatternMessageComponent class],
+                                     @"%level": [K9LogPatternLevelComponent class],
+                                     @"%file": [K9LogPatternFileNameComponent class],
+                                     @"%location": [K9LogPatternFilePathComponent class],
+                                     @"%line": [K9LogPatternLineNumberComponent class],
+                                     @"%method": [K9LogPatternMethodNameComponent class],
                                      };
 
     [klassByPattern enumerateKeysAndObjectsUsingBlock:^(NSString *pattern, Class klass, BOOL *stop) {


### PR DESCRIPTION
There are some people like long descriptive names rather than short compact names.

| Short form | Long form |
| --- | --- |
| `%d` | `%date` |
| `%m` | `%message` |
| `%p` | `%level` |
| `%F` | `%file` |
| `%l` | `%location` |
| `%L` | `%line` |
| `%M` | `%method` |
